### PR TITLE
Add wocProfile v2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -582,6 +582,26 @@ files = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.66.4"
+description = "Fast, Extensible Progress Meter"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tqdm-4.66.4-py3-none-any.whl", hash = "sha256:b75ca56b413b030bc3f00af51fd2c1a1a5eac6a0c1cca83cbb37a5c52abce644"},
+    {file = "tqdm-4.66.4.tar.gz", hash = "sha256:e4d936c9de8727928f3be6079590e97d9abfe8d39a590be678eb5919ffc186bb"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["pytest (>=6)", "pytest-cov", "pytest-timeout", "pytest-xdist"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
+
+[[package]]
 name = "virtualenv"
 version = "20.26.2"
 description = "Virtual Python Environment builder"
@@ -618,4 +638,4 @@ test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "c814018ea216521755e7c6cb1dc2278192f919166580a2ee24133fa4e99f2ee2"
+content-hash = "a6202e19579beed0d73834a99a5fef9a7cd83b25ee807ed1d0f60b0120693b9b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "python-woc"
-version = "0.1.2"
+version = "0.2.0"
 description = "Python interface for World of Code"
 authors = ["Runzhi He <rzhe@pku.edu.cn>", "Marat <marat@cmu.edu>"]
 license = "GPL-3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ generate-setup-file = false
 python = "^3.8"
 python-lzf = "^0.2.4"
 chardet = "^5.2.0"
+tqdm = "^4.66.4"
 
 [tool.poetry.group.build.dependencies]
 cython = "^0.29.0"

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -137,7 +137,7 @@ def test_count(woc):
 def test_version(woc):
     _test_pr = os.path.join(os.path.dirname(__file__), "test_profile.json")
     woc_u = WocMapsLocal(_test_pr, version="U")
-    assert woc_u.maps == {"b2fa", "c2p", "c2dat", "b2tac"}
+    assert {m.name for m in woc_u.maps} == {"b2fa", "c2p", "c2dat", "b2tac"}
     woc_r = WocMapsLocal(_test_pr, version=["R"])
     assert len(woc_u.maps) + len(woc_r.maps) == len(woc.maps)
 
@@ -145,6 +145,4 @@ def test_version(woc):
 def test_exclude_larges(woc):
     _test_pr = os.path.join(os.path.dirname(__file__), "test_profile.json")
     woc_nolarge = WocMapsLocal(_test_pr, exclude_larges=True)
-    assert "larges" not in json.dumps(woc_nolarge.config["maps"]), json.dumps(
-        woc_nolarge.config["maps"]
-    )
+    assert ".large." not in str(woc_nolarge.maps), json.dumps(woc_nolarge.config["maps"])

--- a/woc/base.py
+++ b/woc/base.py
@@ -1,16 +1,55 @@
-from typing import Iterable, List, Literal, Tuple, Union
+from dataclasses import dataclass
+from typing import Dict, List, Literal, Optional, Tuple, Union
 
 WocObjectsWithContent = Literal["tree", "blob", "commit", "tkns", "tag", "bdiff"]
 """WoC objects stored in stacked binary files."""
 
-WocSupportedProfileVersions = (1,)
+WocSupportedProfileVersions = (1, 2)
 """Profile versions supported by the current python-woc."""
 
 
+@dataclass
+class WocFile:
+    """Represents a file in the WoC database."""
+
+    path: str
+    """Path to the file in the local filesystem."""
+
+    size: Optional[int] = None
+    """Size of file in bytes."""
+
+    digest: Optional[str] = None
+    """16-char digest calculated by woc.utils.fast_digest."""
+
+
+@dataclass
+class WocObject:
+    name: str
+    """Name of the map, e.g. 'c2p', 'c2r', 'P2c'."""
+
+    sharding_bits: int
+    """Number of bits used for sharding."""
+
+    shards: List[WocFile]
+    """List of shard files."""
+
+
+@dataclass
+class WocMap(WocObject):
+    version: str
+    """version of the map, e.g. 'R', 'U'."""
+
+    larges: Dict[str, WocFile]
+    """Large files associated with the map."""
+
+    dtypes: Tuple[str, str]
+    """Data types of the map, e.g. ('h', 'cs'), ('h', 'hhwww')."""
+
+
 class WocMapsBase:
-    maps: Iterable[str]
+    maps: List[WocMap]
     """List of basemaps available in the WoC database."""
-    objects: Iterable[str]
+    objects: List[WocObject]
     """List of objects available in the WoC database."""
 
     def __init__(self, *args, **kwargs):

--- a/woc/detect.py
+++ b/woc/detect.py
@@ -11,6 +11,7 @@ import os
 import re
 from functools import cmp_to_key
 from typing import Iterable, Optional, Tuple
+from tqdm import tqdm
 
 from .utils import sample_md5
 
@@ -209,9 +210,7 @@ def detect_profile(
                 or (not f.startswith("pack") and f.endswith(".idx"))
                 or f.endswith(".bin")
             ]
-            for idx, f in enumerate(files):
-                if idx % 1000 == 0:
-                    _logger.info(f"Processing {f} in {path}, {idx+1}/{len(files)}")
+            for idx, f in enumerate(tqdm(files, desc=root)):
 
                 _r = parse_map_fname(f)
                 if _r:

--- a/woc/local.pyx
+++ b/woc/local.pyx
@@ -846,8 +846,8 @@ class WocMapsLocal(WocMapsBase):
             raise KeyError(f'Invalid map name: {map_name}, '
                 f'expect one of {", ".join(self._lookup.keys())}')
 
-        _count = len(_map["larges"]) if "larges" in _map else 0
-        for _shard in _map["shards"]:
+        _count = len(_map.larges) if hasattr(_map, "larges") else 0
+        for _shard in _map.shards:
             _tch = get_tch(_shard.path)
             _count += len(_tch)
 

--- a/woc/utils.py
+++ b/woc/utils.py
@@ -1,0 +1,46 @@
+import hashlib
+import os
+
+
+def sample_md5(file_path: str, skip=0, size=None) -> str:
+    """
+    Divide the file into chunks and calculate the MD5 digest of the first 128 bytes of each chunk.
+
+    :param file_path: The path to the file.
+    :param skip: The number of bytes to skip from the beginning of the file. Defaults to 0.
+    :param size: The number of bytes to for hashing. If None, the entire file (minus the skip) is considered.
+    :return: A tuple containing the size of the considered portion and the 16-character MD5 digest.
+    """
+
+    fsize = os.path.getsize(file_path)
+
+    if size is None:
+        size = fsize - skip
+    assert (
+        skip + size <= fsize
+    ), f"supplied size {size}B > file size {os.path.getsize(file_path)}B"
+
+    dig = hashlib.md5()
+
+    # hash all bytes if file is small
+    if size <= 4096:  # typical block size of ext4
+        with open(file_path, "rb") as f:
+            f.seek(skip)
+            dig.update(f.read(size))
+            return size, dig.hexdigest()[:16]
+
+    # A heuristic to find the optimal chunk size
+    # Number of chunks is between 2 and 8, chunk size must be a power of 2
+    chunk_size = 2 ** ((size // size.bit_length()).bit_length() + 2)
+    num_chunks = (size - 256) // chunk_size  # don't hash the same bytes twice
+
+    with open(file_path, "rb") as f:
+        f.seek(skip)
+        dig.update(f.read(128))
+        for _ in range(num_chunks):
+            f.seek(chunk_size - 128, os.SEEK_CUR)
+            dig.update(f.read(128))
+        f.seek(skip + size - 128)
+        dig.update(f.read(128))
+
+    return dig.hexdigest()[:16]

--- a/woc/verify.py
+++ b/woc/verify.py
@@ -1,0 +1,51 @@
+import logging
+import os
+
+from woc.base import WocFile
+from woc.local import WocMapsLocal
+from woc.utils import sample_md5
+
+
+def check_file(fobj: WocFile):
+    assert fobj.size == os.path.getsize(
+        fobj.path
+    ), f"Size mismatch for {fobj.path}: {os.path.getsize(fobj.path)} != {fobj.size}"
+
+    if not fobj.digest:
+        return
+
+    _digest = sample_md5(fobj.path)
+    assert (
+        _digest == fobj.digest
+    ), f"Digest mismatch for {fobj.path}: {_digest} != {fobj.digest}"
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Checks integrity of WoC files")
+    parser.add_argument(
+        "-p", "--profile", type=str, help="The path to the profile file", default=None
+    )
+    args = parser.parse_args()
+
+    woc = WocMapsLocal(args.profile)
+    errs = []
+    files_to_check = []
+    for obj in woc.objects:
+        files_to_check.extend(obj.shards)
+    for obj in woc.maps:
+        files_to_check.extend(obj.larges.values())
+        files_to_check.extend(obj.shards)
+    files_to_check = list(filter(lambda x: x, files_to_check))
+
+    for fobj in files_to_check:
+        try:
+            check_file(fobj)
+        except AssertionError as e:
+            logging.error(e)
+            errs.append(fobj.path)
+
+    if errs:
+        logging.error(f"Errors found in the following files: {errs}")
+        raise AssertionError("Errors found in some files")

--- a/woc/verify.py
+++ b/woc/verify.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from tqdm import tqdm
 
 from woc.base import WocFile
 from woc.local import WocMapsLocal
@@ -39,7 +40,7 @@ if __name__ == "__main__":
         files_to_check.extend(obj.shards)
     files_to_check = list(filter(lambda x: x, files_to_check))
 
-    for fobj in files_to_check:
+    for fobj in tqdm(files_to_check, desc="Checking files"):
         try:
             check_file(fobj)
         except AssertionError as e:

--- a/woc/wocprofile.default.json
+++ b/woc/wocprofile.default.json
@@ -1,5 +1,5 @@
 {
-    "wocSchemaVersion": 1,
+    "wocSchemaVersion": 2,
     "entities": {
         "a": "author",
         "A": "author_unalised",


### PR DESCRIPTION
Woc is a huuugee dataset of hundreds of files and hundreds of terabytes. To make sure everything is in good shape after transmission, wocProfile v2 adds an optional digest field to verify the integrity of each of the files.

To create a wocProfile with file digests:
```bash
python3 -m woc.detect /woc --with-digest > wocprofile.json
```

To verify the digests:
```bash
python3 -m woc.verify --profile wocprofile.json
```

This PR does not break the old profile schema (v1).